### PR TITLE
Update URLs after repo move

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <version>0.9.0-SNAPSHOT</version>
   <name>PASS Client Tool</name>
   <description>Client for interacting with the PASS Fedora+LDP repository</description>
-  <url>https://github.com/OA-PASS/java-fedora-client</url>
+  <url>https://github.com/eclipse-pass/pass-java-client</url>
 
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,6 @@
     <unitils.version>3.4.6</unitils.version>
     <okhttp.version>4.2.2</okhttp.version>
     <log4j2.version>2.14.1</log4j2.version>
-
-    <checkstyle.suppressions.file>duraspace-checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.file>
   </properties>
 
   <build>
@@ -463,9 +461,9 @@
 
 
   <scm>
-    <connection>scm:git:https://github.com/OA-PASS/java-fedora-client.git</connection>
-    <developerConnection>scm:git:https://github.com/OA-PASS/java-fedora-client.git</developerConnection>
-    <url>https://github.com/OA-PASS/java-fedora-client</url>
+    <connection>scm:git:https://github.com/eclipse-pass/java-fedora-client.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/java-fedora-client.git</developerConnection>
+    <url>https://github.com/eclipse-pass/java-fedora-client</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -461,9 +461,9 @@
 
 
   <scm>
-    <connection>scm:git:https://github.com/eclipse-pass/java-fedora-client.git</connection>
-    <developerConnection>scm:git:https://github.com/eclipse-pass/java-fedora-client.git</developerConnection>
-    <url>https://github.com/eclipse-pass/java-fedora-client</url>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-java-client.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-java-client.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-java-client</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
* Update GH repo URLs

Note:

Has a similar problem to previous PR(s): we now depend on a project POM that is not yet published -- and in fact requires changes to the project POM that are currently in PR form. Must update this POM for the CI workaround to work before progressing this PR