### PR TITLE
adjust groupIds to org.eclipse-pass

### DIFF
--- a/pass-client-api/pom.xml
+++ b/pass-client-api/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>
@@ -12,7 +12,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-model</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>
@@ -197,19 +197,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-model</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-data-client</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-status-service</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pass-client-integration/pom.xml
+++ b/pass-client-integration/pom.xml
@@ -215,7 +215,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-client-shaded-v2_3</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/pass-client-shaded-v2_3/pom.xml
+++ b/pass-client-shaded-v2_3/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>
@@ -43,8 +43,8 @@
               <shadeSourcesContent>true</shadeSourcesContent>
               <relocations>
                 <relocation>
-                  <shadedPattern>org.dataconservancy.pass.v2_3</shadedPattern>
-                  <pattern>org.dataconservancy.pass</pattern>
+                  <shadedPattern>org.eclipse.pass.v2_3</shadedPattern>
+                  <pattern>org.eclipse.pass</pattern>
                 </relocation>
               </relocations>
               <transformers>

--- a/pass-client-shaded-v2_3/pom.xml
+++ b/pass-client-shaded-v2_3/pom.xml
@@ -43,8 +43,8 @@
               <shadeSourcesContent>true</shadeSourcesContent>
               <relocations>
                 <relocation>
-                  <shadedPattern>org.eclipse.pass.v2_3</shadedPattern>
-                  <pattern>org.eclipse.pass</pattern>
+                  <shadedPattern>org.dataconservancy.pass.v2_3</shadedPattern>
+                  <pattern>org.dataconservancy.pass</pattern>
                 </relocation>
               </relocations>
               <transformers>

--- a/pass-client-util/pom.xml
+++ b/pass-client-util/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>

--- a/pass-data-client/pom.xml
+++ b/pass-data-client/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>
@@ -12,19 +12,19 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-model</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-json-adapter</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-client-util</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/pass-json-adapter/pom.xml
+++ b/pass-json-adapter/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>
@@ -16,19 +16,19 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-model</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-client-api</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-client-util</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -51,7 +51,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-test-data</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/pass-model/pom.xml
+++ b/pass-model/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>
@@ -29,7 +29,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-test-data</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/pass-status-service/pom.xml
+++ b/pass-status-service/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>
@@ -11,13 +11,13 @@
   <name>PASS Status Utility</name>
   <dependencies>
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-client-api</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-data-client</artifactId>
       <version>${project.parent.version}</version>
     </dependency>

--- a/pass-test-data/pom.xml
+++ b/pass-test-data/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.dataconservancy.pass</groupId>
+    <groupId>org.eclipse.pass</groupId>
     <artifactId>pass-client</artifactId>
     <version>0.9.0-SNAPSHOT</version>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.dataconservancy.pass</groupId>
+  <groupId>org.eclipse.pass</groupId>
   <artifactId>pass-client</artifactId>
   <packaging>pom</packaging>
   <version>0.9.0-SNAPSHOT</version>


### PR DESCRIPTION
groupIds were adjusted for all artifacts, and some updates were necessary in constructing the shaded jar. there is an integration test for comparing gbehavior of the current client with a previous version (v2.3) - this last artifact retains the dataconservancy groupId, and is scoped to test. this was necessary to get `mvn clean install `to succeed.

see poms for `pass-client-integration` and `pass-client-shaded-v2_3` for this weirdness